### PR TITLE
Update and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ below.**
     ```
 
 2.  Follow the `README.md` instructions in the
-    [multi\_site](https://github.com/NREL/REopt-API-Analysis/multi_site/README.md) or
-    [single\_site](https://github.com/NREL/REopt-API-Analysis/single_site/README.md) directories
+    [multi\_site](multi_site/README.md) or
+    [single\_site](single_site/README.md) directories


### PR DESCRIPTION
# Motivation

The two links at the bottom of the README don't work.  

# Changes

- Update broken links to multi and single site instruction with [relative links](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes#relative-links-and-image-paths-in-readme-files)