### PR TITLE
Updated the multi_site_inputs_parser.py to allow scenario specific electric tariffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # REopt API Analysis using Python
 
 ## Updated for Multi-Scenario and Multi-Tariff Inputs
-This fork of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff for each scenario. Below is an example of some inputs:
+This fork of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular, it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff to be specified for each scenario. Below is an example of some inputs:
 
 | description  | load_file | rate_file |
 | ------------- | ------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # REopt API Analysis using Python
 
 ## Updated for Multi-Scenario and Multi-Tariff Inputs
-This version of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff for each scenario. Below is an example of some inputs:
+This fork of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff for each scenario. Below is an example of some inputs:
 
 | description  | load_file | rate_file |
 | ------------- | ------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # REopt API Analysis using Python
 
+## Updated for Multi-Scenario and Multi-Tariff Inputs
+This version of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff for each scenario. Below is an example of some inputs:
+
+| description  | load_file | rate_file |
+| ------------- | ------------- | ------------- |
+| 87104  | 87104_load_kw.csv  | 87104_electric_tariff.json  |
+| 87106  | 87106_load_kw.csv  | 87106_electric_tariff.json  |
+
+The multi-scenario example in the original repository notes that you must post a singular electric rate tariff, but this allows any number of tariffs to be posted as long as they are in the input file under this column header.
+
+#
 [REopt](https://reopt.nrel.gov/) is a techno-economic decision support model
 from NREL which is used for optimizing energy systems for buildings, campuses,
 communities, and microgrids. [REopt Lite](https://reopt.nrel.gov/tool) offers any

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # REopt API Analysis using Python
 
 ## Updated for Multi-Scenario and Multi-Tariff Inputs
-This fork of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular, it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff to be specified for each scenario. Below is an example of some inputs:
+We now have now have the ability to use multiple custom electric tariffs with the multi-scenario version of the program. In particular, it allows the addition of a column in the multi-scenario input file titled `urdb_json_file` that allows a specific electric tariff to be specified for each scenario. Below is an example of some inputs:
 
-| description  | load_file | rate_file |
-| ------------- | ------------- | ------------- |
-| 87104  | 87104_load_kw.csv  | 87104_electric_tariff.json  |
-| 87106  | 87106_load_kw.csv  | 87106_electric_tariff.json  |
-
-The multi-scenario example in the original repository notes that you must post a singular electric rate tariff, but this allows any number of tariffs to be posted as long as they are in the input file under this column header.
+| description  | load_file | urdb_json_file | urdb_label |
+| ------------- | ------------- | ------------- | ------------- |
+| 87104  | 87104_load_kw.csv  | 87104_electric_tariff.json  | 87104_electric_tariff.json  |
+| 87106  | 87106_load_kw.csv  | 87106_electric_tariff.json  | 87106_electric_tariff.json  |
+| 87106  | 87106_load_kw.csv  |   | 5cc090b85457a3a43667107e  |
+ 
+The user can specify the location of a json file that is placed within `./electric_rates/` or a urdb_label as usual. This is useful for when users have scenarios looking at multiple different customer classes that may face different rate structures.
 
 #
 [REopt](https://reopt.nrel.gov/) is a techno-economic decision support model

--- a/src/multi_site_inputs_parser.py
+++ b/src/multi_site_inputs_parser.py
@@ -134,7 +134,7 @@ def multi_site_csv_parser(path_to_csv, api_url, API_KEY, n_sites=None):
         path_to_rate_files = "./electric_rates"
         if "urdb_json_file" in df.columns:
             if pd.isnull(df.loc[i,"urdb_json_file"]) == False:
-                rate_i = json.load(open(os.path.join(path_to_urdb_json_files, df["urdb_json_file"][i]), "r"))
+                rate_i = json.load(open(os.path.join(path_to_rate_files, df["urdb_json_file"][i]), "r"))
                 posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_i
             elif pd.isnull(df.loc[i,"urdb_json_file"]) == True and pd.isnull(df.loc[i,"urdb_label"]) == True:
                 print("Push Failed: Missing electric tariff information for Site Number",df['site_number'][i])

--- a/src/multi_site_inputs_parser.py
+++ b/src/multi_site_inputs_parser.py
@@ -132,9 +132,17 @@ def multi_site_csv_parser(path_to_csv, api_url, API_KEY, n_sites=None):
         add_load_profile_inputs(site_inputs, posts[-1], path_to_load_files=path_to_load_files)
         
         path_to_rate_files = "./electric_rates"
-        for x in df['rate_file'].tolist():
-            rate_x = json.load(open(os.path.join(path_to_rate_files, x), "r"))
-            posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_x
+        if "urdb_json_file" in df.columns:
+            if pd.isnull(df.loc[i,"urdb_json_file"]) == False:
+                rate_i = json.load(open(os.path.join(path_to_urdb_json_files, df["urdb_json_file"][i]), "r"))
+                posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_i
+            elif pd.isnull(df.loc[i,"urdb_json_file"]) == True and pd.isnull(df.loc[i,"urdb_label"]) == True:
+                print("Push Failed: Missing electric tariff information for Site Number",df['site_number'][i])
+                exit()            
+            else:
+                pass
+        else:
+            pass
 
         posts[i]['Scenario']['Site']['Wind'] = {'max_kw': 0}  # hack for Wind not in help endpoint
 

--- a/src/multi_site_inputs_parser.py
+++ b/src/multi_site_inputs_parser.py
@@ -135,10 +135,7 @@ def multi_site_csv_parser(path_to_csv, api_url, API_KEY, n_sites=None):
         if "urdb_json_file" in df.columns:
             if pd.isnull(df.loc[i,"urdb_json_file"]) == False:
                 rate_i = json.load(open(os.path.join(path_to_rate_files, df["urdb_json_file"][i]), "r"))
-                posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_i
-            elif pd.isnull(df.loc[i,"urdb_json_file"]) == True and pd.isnull(df.loc[i,"urdb_label"]) == True:
-                print("Push Failed: Missing electric tariff information for Site Number",df['site_number'][i])
-                exit()            
+                posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_i           
             else:
                 pass
         else:

--- a/src/multi_site_inputs_parser.py
+++ b/src/multi_site_inputs_parser.py
@@ -130,6 +130,11 @@ def multi_site_csv_parser(path_to_csv, api_url, API_KEY, n_sites=None):
 
         path_to_load_files = "./load_profiles"
         add_load_profile_inputs(site_inputs, posts[-1], path_to_load_files=path_to_load_files)
+        
+        path_to_rate_files = "./electric_rates"
+        for x in df['rate_file'].tolist():
+            rate_x = json.load(open(os.path.join(path_to_rate_files, x), "r"))
+            posts[i]["Scenario"]["Site"]["ElectricTariff"]["urdb_response"] = rate_x
 
         posts[i]['Scenario']['Site']['Wind'] = {'max_kw': 0}  # hack for Wind not in help endpoint
 


### PR DESCRIPTION
This fork of the repository includes an updated version of `src.multi_site_input_parser.py`. In particular, it allows the addition of a column in the multi-scenario input file titled `rate_file` that allows a specific electric tariff to be specified for each scenario. Below is an example of some inputs:

| description  | load_file | rate_file |
| ------------- | ------------- | ------------- |
| 87104  | 87104_load_kw.csv  | 87104_electric_tariff.json  |
| 87106  | 87106_load_kw.csv  | 87106_electric_tariff.json  |

The multi-scenario example in the original repository notes that you must post a singular electric rate tariff, but this allows any number of tariffs to be posted as long as they are in the input file under this column header.

The readme file is probably something you don't want to commit, but if you find this a useful addition to the parser file then let me know. Everything was tested and works on my end.